### PR TITLE
[ServiceDiscovery] Now with Fewer Args At #new Time™

### DIFF
--- a/lib/fog/openstackcore/core.rb
+++ b/lib/fog/openstackcore/core.rb
@@ -1,9 +1,12 @@
 require 'fog/openstackcore/errors'
+require 'fog/openstackcore/service_discovery'
 
 module Fog
   module OpenStackCore
     extend Fog::Provider
     include Fog::OpenStackCore::Errors
+
+    ServiceDiscovery.register_provider('openstackcore', 'Fog::OpenStackCore', 'fog/openstackcore/services')
 
     service(:identity,     'Identity')
     # service(:compute ,      'Compute')

--- a/lib/fog/openstackcore/identity.rb
+++ b/lib/fog/openstackcore/identity.rb
@@ -7,11 +7,17 @@ module Fog
     # what version is required.
 
     class Identity
-      ServiceDiscovery.register_service(self)
+      def self.new(options, connection_options = {})
+        initialize_service(options, connection_options)
+      end
 
-      def self.new(options = {})
-        service_discovery = ServiceDiscovery.new("identity", options)
-        service_discovery.call
+      private
+
+      def self.initialize_service(options, connection_options = {})
+        opts = options.dup  # dup options so no wonky side effects
+        opts.merge!(:connection_options => connection_options)
+
+        ServiceDiscovery.new('openstackcore', 'identity', opts).call
       end
 
     end # Identity

--- a/spec/fixtures/fog/fakeprovider/services/foobar_v2.rb
+++ b/spec/fixtures/fog/fakeprovider/services/foobar_v2.rb
@@ -1,5 +1,5 @@
 module Fog
-  module OpenStackCore
+  module FakeProvider
     class FoobarV2
       def initialize(opts); end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,6 @@ VCR.configure do |c|
 end
 
 MinitestVcr::Spec.configure!
-Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
+#Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 # VCR.turn_off!(:ignore_cassettes => true)


### PR DESCRIPTION
Ok, fewer keyword args, anyway...

Because the same service may exist in multiple providers, e.g. …
`IdentityV2` will be in both Rackspace and HP, it became necessary
for the `ServiceDiscovery` to register the provider's name when
registering the "base_provider_path".

What also shook out of this is that "base_provider" probably
only needs to be stated once: when the provider is registered
with `ServiceDiscovery`.

Now, providers register with a single call as follows:

``` ruby
ServiceDiscovery.register_provider(
    'openstackcore',
    'Fog::OpenStackCore',
    'the/path/to/osc/services'
)
```

and `ServiceDiscovery` is now instantiated as follows:

``` ruby
ServiceDiscovery.new('openstackcore', 'identity', options_hash)
```

and `base_provider` is no longer an option as this is specified once and only once for any given provider.  For instance, it is specified for OSC in `Fog::OpenStackCore`.  OSC itself is treated just as any other OpenStack provider in this case. 
